### PR TITLE
Add Jupyter-style cell outputs to Out

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - `image/png` rendering via `kittytgp`
 - matplotlib inline support
 - Includes display objects, streams, and rich results in stored history
+- Stores complete Jupyter-style cell outputs in `Out[n]`
 
 ## Install
 
@@ -30,6 +31,24 @@ ipython --ext ipythonng
 ```
 
 For matplotlib, `%matplotlib inline` works with the existing `image/png` renderer. No custom matplotlib backend is needed. Using `exec_lines` runs the magic after extensions load.
+
+## Cell outputs
+
+`Out[n]` contains the ordered outputs from cell `n` as Jupyter-style dictionaries. This includes Python results, stdout and stderr, errors, rich displays, and shell command output:
+
+```python
+Out[3]
+# [{'output_type': 'stream', 'name': 'stdout', 'text': 'hello\n'}]
+```
+
+Rich display data is stored as a MIME bundle. PNGs use Jupyter's base64 representation and can be decoded directly:
+
+```python
+from base64 import b64decode
+png = b64decode(Out[4][0]['data']['image/png'])
+```
+
+Loading `ipythonng` intentionally changes standard IPython behavior: each `Out[n]` is a list containing every output from that cell, rather than only the final Python expression.
 
 ## Convenience launcher
 

--- a/ipythonng/extension.py
+++ b/ipythonng/extension.py
@@ -1,9 +1,10 @@
 import base64,fcntl,inspect,io,os,pty,signal,sys,termios,tty
-from contextlib import redirect_stdout
+from contextlib import contextmanager,redirect_stdout
 from types import MethodType
 from typing import Any
 
 from fastcore.basics import patch,patch_to
+from IPython.core.history import HistoryOutput
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.core.ultratb import SyntaxTB
 from kittytgp import build_render_bytes
@@ -67,6 +68,16 @@ def _set_pty_size(master_fd):
         fcntl.ioctl(master_fd, termios.TIOCSWINSZ, sz)
     except Exception: pass
 
+def _add_stream(shell, text, typ="out_stream"):
+    shell.history_manager.outputs[shell.execution_count-1].append(HistoryOutput(typ, {"stream": [text]}))
+
+@contextmanager
+def _publishing(shell):
+    pub,prev = shell.display_pub,shell.display_pub._is_publishing
+    pub._is_publishing = True
+    try: yield
+    finally: pub._is_publishing = prev
+
 def _system_pty(self, cmd):
     "Run `cmd` in a PTY so interactive programs work, capturing output for history."
     from fastcore.xtras import clean_cli_output
@@ -97,9 +108,7 @@ def _system_pty(self, cmd):
     self.user_ns['_exit_code'] = exit_code
     raw = b''.join(captured).decode('utf-8', errors='replace')
     clean = clean_cli_output(raw)
-    if clean.strip():
-        ext = getattr(self, '_ipythonng_extension', None)
-        if ext: ext._pty_output = clean
+    if clean.strip(): _add_stream(self, clean)
 
 
 class IPythonNGExtension:
@@ -114,7 +123,6 @@ class IPythonNGExtension:
         self._added_active_types = set()
         self._original_enable_matplotlib = None
         self._original_system = None
-        self._pty_output = None
 
     def load(self):
         self._install_renderers()
@@ -245,9 +253,11 @@ class IPythonNGExtension:
         if self._needs_execute_result_newline(): self._write("\n")
         self._write(payload.decode("utf-8"))
 
-    def _handle_text_markdown(self, markdown_text: str, metadata=None): self._render_markdown(markdown_text)
+    def _handle_text_markdown(self, markdown_text: str, metadata=None):
+        with _publishing(self.shell): self._render_markdown(markdown_text)
 
-    def _handle_image_png(self, png_b64: str, metadata=None): self._render_png(png_b64, metadata)
+    def _handle_image_png(self, png_b64: str, metadata=None):
+        with _publishing(self.shell): self._render_png(png_b64, metadata)
 
     def _render_history_output(self, output) -> str:
         if output.output_type in {"out_stream", "err_stream"}: return "".join(output.bundle.get("stream", []))
@@ -276,16 +286,29 @@ class IPythonNGExtension:
         if not pieces: return None
         return "".join(pieces)
 
+    def _cell_outputs(self, n):
+        "Jupyter-style outputs for cell `n`."
+        res = []
+        for o in self.history_manager.outputs.get(n, []):
+            data = {k:list(v) if isinstance(v,list) else v for k,v in o.bundle.items()}
+            if o.output_type in {"out_stream", "err_stream"}:
+                txt = ''.join(''.join(v) if isinstance(v,list) else v for v in data.values())
+                res.append(dict(output_type="stream", name="stderr" if o.output_type=="err_stream" else "stdout", text=txt))
+            elif o.output_type == "display_data": res.append(dict(output_type="display_data", data=data, metadata={}))
+            elif o.output_type == "execute_result": res.append(dict(output_type="execute_result", execution_count=n, data=data, metadata={}))
+            else: raise ValueError(f"Unknown output type: {o.output_type}")
+        if exc := self.history_manager.exceptions.get(n): res.append(dict(output_type="error", **exc))
+        return res
+
     def _finalize_history(self, result):
         execution_count = getattr(result, "execution_count", None)
         if execution_count is None: return
 
         flat_output = self._flatten_output(execution_count)
-        if flat_output is None:
-            flat_output = getattr(self, '_pty_output', None)
-            self._pty_output = None
         if flat_output is not None: self.history_manager.output_hist_reprs[execution_count] = flat_output
         else: self.history_manager.output_hist_reprs.pop(execution_count, None)
+
+        self.shell.user_ns["Out"][execution_count] = self._cell_outputs(execution_count)
 
         should_store = self.history_manager.db_log_output and flat_output is not None
         self._pending_store_output.discard(execution_count)

--- a/tests/test_ipythonng.py
+++ b/tests/test_ipythonng.py
@@ -1,4 +1,4 @@
-import base64, io
+import base64,io,sys
 
 import kittytgp.core as kittycore, pytest
 from IPython.terminal.interactiveshell import TerminalInteractiveShell
@@ -6,11 +6,15 @@ from kittytgp import build_render_bytes
 from kittytgp.core import PLACEHOLDER
 from traitlets.config import Config
 
-from ipythonng import load_ipython_extension
+from ipythonng import load_ipython_extension,unload_ipython_extension
 from ipythonng.cli import parse_flags
 
 PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAIAAAADCAQAAABi6S9dAAAADElEQVR42mNkYPhfDwADhgGAff/3fwAAAABJRU5ErkJggg=="
 PNG_BYTES = base64.b64decode(PNG_B64)
+
+def cell_out(shell, code):
+    res = shell.run_cell(code, store_history=True)
+    return shell.user_ns["Out"][res.execution_count]
 
 
 class FakeTerminal(io.StringIO):
@@ -81,6 +85,26 @@ def test_tracebacks_are_included_in_flattened_output(shell):
     (_, _, (_, output)) = list(shell.history_manager.get_range(output=True))[-1]
     assert "ZeroDivisionError" in output
     assert "division by zero" in output
+
+
+def test_out_stores_jupyter_result(shell):
+    assert cell_out(shell, "1+1") == [{
+        "output_type": "execute_result", "execution_count": 1,
+        "data": {"text/plain": "2"}, "metadata": {}}]
+
+
+def test_out_stores_stdout_and_stderr(shell):
+    out = cell_out(shell, "import sys\nprint('hello')\nprint('oops', file=sys.stderr)")
+    assert out == [
+        {"output_type": "stream", "name": "stdout", "text": "hello\n"},
+        {"output_type": "stream", "name": "stderr", "text": "oops\n"}]
+
+
+def test_out_stores_error(shell):
+    out = cell_out(shell, "1/0")
+    assert len(out) == 1 and out[0]["output_type"] == "error"
+    assert out[0]["ename"] == "ZeroDivisionError"
+    assert out[0]["evalue"] == "division by zero"
 
 
 def test_kitty_rendering_matches_kittytgp_outside_tmux(shell, monkeypatch):
@@ -197,11 +221,70 @@ def test_matplotlib_inline_after_prior_plot_renders_future_plots(shell, monkeypa
     assert "display_data" in output_types
 
 
+def test_out_stores_display_image(shell):
+    out = cell_out(shell, """import base64
+from IPython.display import Image,display
+display(Image(data=base64.b64decode(%r), format='png'))
+""" % PNG_B64)
+    assert [o["output_type"] for o in out] == ["display_data"]
+    assert out[0]["data"]["image/png"] == PNG_B64
+
+
+def test_out_stores_image_result(shell):
+    out = cell_out(shell, """import base64
+from IPython.display import Image
+Image(data=base64.b64decode(%r), format='png')
+""" % PNG_B64)
+    assert [o["output_type"] for o in out] == ["execute_result"]
+    assert out[0]["data"]["image/png"] == PNG_B64
+
+
+def test_out_preserves_mixed_output_order(shell):
+    out = cell_out(shell, """import base64
+from IPython.display import Image,display
+print('before')
+display(Image(data=base64.b64decode(%r), format='png'))
+print('after')
+42
+""" % PNG_B64)
+    assert [o["output_type"] for o in out] == ["stream", "display_data", "stream", "execute_result"]
+    assert out[0]["text"] == "before\n"
+    assert out[1]["data"]["image/png"] == PNG_B64
+    assert out[2]["text"] == "after\n"
+    assert out[3]["data"]["text/plain"] == "42"
+
+
+def test_renderer_bytes_are_not_stored(shell, monkeypatch):
+    monkeypatch.setattr(shell, "_ipythonng_stream", sys.stdout)
+    out = cell_out(shell, """import base64
+from IPython.display import Image,display
+display(Image(data=base64.b64decode(%r), format='png'))
+""" % PNG_B64)
+    assert [o["output_type"] for o in out] == ["display_data"]
+    assert all("\x1b_G" not in o.get("text", "") for o in out)
+
+
 def test_system_pty_captures_output_in_history(shell):
     shell.history_manager.db_log_output = True
     shell.run_cell("!echo hello_pty_test", store_history=True)
     (_, _, (_, output)) = list(shell.history_manager.get_range(output=True))[-1]
     assert "hello_pty_test" in output
+
+
+def test_system_pty_captures_output_in_out(shell):
+    out = cell_out(shell, "!echo hello_out_test")
+    assert out == [{"output_type": "stream", "name": "stdout", "text": "hello_out_test\n"}]
+
+
+def test_rehashed_command_captures_output_in_out(shell):
+    shell.run_cell("%rehashx", store_history=True)
+    out = cell_out(shell, "echo hello_rehash_test")
+    assert out == [{"output_type": "stream", "name": "stdout", "text": "hello_rehash_test\n"}]
+
+
+def test_system_pty_preserves_stream_order(shell):
+    out = cell_out(shell, "print('before')\nget_ipython().system('echo middle')\nprint('after')")
+    assert ''.join(o["text"] for o in out) == "before\nmiddle\nafter\n"
 
 
 def test_system_pty_output_persists_across_sessions(shell):
@@ -232,6 +315,7 @@ def test_system_pty_alternate_screen_returns_empty(shell):
     ec = shell.execution_count - 1
     output = shell.history_manager.output_hist_reprs.get(ec, "")
     assert output.strip() == ""
+    assert shell.user_ns["Out"][ec] == []
 
 
 def test_system_pty_strips_ansi(shell):
@@ -240,6 +324,14 @@ def test_system_pty_strips_ansi(shell):
     output = shell.history_manager.output_hist_reprs.get(ec, "")
     assert "red text" in output
     assert "\x1b[" not in output
+
+
+def test_unload_keeps_old_out_and_restores_standard_cache(shell):
+    old = cell_out(shell, "1+1")
+    unload_ipython_extension(shell)
+    res = shell.run_cell("2+2", store_history=True)
+    assert shell.user_ns["Out"][1] == old
+    assert shell.user_ns["Out"][res.execution_count] == 4
 
 
 def test_parse_flags_combined_short_flags():


### PR DESCRIPTION
## Summary
- Store complete Jupyter-style cell output records in Out[n]
- Capture PTY command output as ordered stdout stream records
- Preserve rich display MIME bundles, including PNG data

## Tests
- uv run --no-project --with pytest --with-editable . pytest -q