### PR TITLE
Fix pty output dropped and leaked across cells

### DIFF
--- a/ipythonng/extension.py
+++ b/ipythonng/extension.py
@@ -231,7 +231,7 @@ class IPythonNGExtension:
 
         target = _RenderTarget(stream)
         try:
-            png_bytes = base64.b64decode(png_b64)
+            png_bytes = png_b64 if isinstance(png_b64, bytes) else base64.b64decode(png_b64)
             payload = build_render_bytes(png_bytes, out=target)
         except RuntimeError:
             try:

--- a/ipythonng/extension.py
+++ b/ipythonng/extension.py
@@ -4,6 +4,7 @@ from types import MethodType
 from typing import Any
 
 from fastcore.basics import patch,patch_to
+from IPython.core.history import HistoryOutput
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.core.ultratb import SyntaxTB
 from kittytgp import build_render_bytes
@@ -277,13 +278,12 @@ class IPythonNGExtension:
         return "".join(pieces)
 
     def _finalize_history(self, result):
+        pty_output,self._pty_output = self._pty_output,None
         execution_count = getattr(result, "execution_count", None)
         if execution_count is None: return
 
+        if pty_output: self.history_manager.outputs[execution_count].append(HistoryOutput(output_type="out_stream", bundle={"stream": [pty_output]}))
         flat_output = self._flatten_output(execution_count)
-        if flat_output is None:
-            flat_output = getattr(self, '_pty_output', None)
-            self._pty_output = None
         if flat_output is not None: self.history_manager.output_hist_reprs[execution_count] = flat_output
         else: self.history_manager.output_hist_reprs.pop(execution_count, None)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "IPython extension for terminal markdown, kitty images, and richer
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "fastcore>=1.13",
     "ipython>=9.0",
     "kittytgp>=0.0.2",
     "rich>=13.0",

--- a/tests/test_ipythonng.py
+++ b/tests/test_ipythonng.py
@@ -120,6 +120,26 @@ Image(data=base64.b64decode(%r), format="png")
     assert rendered == "\n" + expected
 
 
+def test_raw_png_bytes_render_like_pil(shell, monkeypatch):
+    "PIL-style _repr_png_ returns raw bytes, not base64 str like matplotlib/IPython.display.Image"
+    monkeypatch.delenv("TMUX", raising=False)
+    monkeypatch.setattr(kittycore.secrets, "randbelow", lambda _: 0x555555 - 1)
+
+    shell.run_cell(
+        """
+import base64
+class RawPng:
+    def _repr_png_(self): return base64.b64decode(%r)
+RawPng()
+"""
+        % PNG_B64, store_history=True)
+
+    rendered = shell._ipythonng_stream.getvalue()
+    expected = build_render_bytes(PNG_BYTES, out=GeometryProbe(), cell_width_px=8, cell_height_px=16).decode("utf-8")
+    assert rendered == "\n" + expected
+    assert "[image/png]" not in rendered
+
+
 def test_kitty_rendering_matches_kittytgp_inside_tmux(shell, monkeypatch):
     monkeypatch.setenv("TMUX", "/tmp/tmux")
     monkeypatch.setattr(kittycore.secrets, "randbelow", lambda _: 0x654321 - 1)

--- a/tests/test_ipythonng.py
+++ b/tests/test_ipythonng.py
@@ -234,6 +234,28 @@ def test_system_pty_alternate_screen_returns_empty(shell):
     assert output.strip() == ""
 
 
+def test_system_pty_output_recorded_in_history_outputs(shell):
+    shell.run_cell("!echo in_outputs", store_history=True)
+    ec = shell.execution_count - 1
+    outs = shell.history_manager.outputs.get(ec, [])
+    streams = ["".join(o.bundle.get("stream", [])) for o in outs if o.output_type == "out_stream"]
+    assert any("in_outputs" in s for s in streams)
+
+
+def test_system_pty_merges_with_printed_output(shell):
+    shell.run_cell("print('printed'); get_ipython().system('echo from_pty')", store_history=True)
+    ec = shell.execution_count - 1
+    output = shell.history_manager.output_hist_reprs.get(ec, "")
+    assert "printed" in output and "from_pty" in output
+
+
+def test_system_pty_does_not_leak_into_next_cell(shell):
+    shell.run_cell("print('x'); get_ipython().system('echo leaky')", store_history=True)
+    shell.run_cell("pass", store_history=True)
+    ec = shell.execution_count - 1
+    assert "leaky" not in shell.history_manager.output_hist_reprs.get(ec, "")
+
+
 def test_system_pty_strips_ansi(shell):
     shell.run_cell(r"!printf '\x1b[31mred\x1b[0m text'", store_history=True)
     ec = shell.execution_count - 1


### PR DESCRIPTION
Previously, `_system_pty` stashed captured output in a side-channel that `_finalize_history` only consulted when a cell displayed nothing else. This dropped shell output whenever a cell also printed, and leaked stale output into the next cell's history.

 **Changes:**
 - Append pty output as an `out_stream` `HistoryOutput` to `history_manager.outputs` instead of using a side-channel stash
 - Let `_flatten_output` pick up pty output through the normal path
 - Add `fastcore>=1.13` dependency (needed for `@patch` `_orig_` stashing)
 - Add tests verifying output is recorded, merges with printed output, and does not leak into the next cell

## Also: render raw PNG bytes (PIL images)

`_render_png` assumed every `image/png` payload is a base64 str. That holds for matplotlib figures (`print_figure(..., base64=True)`) and `IPython.display.Image`, but PIL's `_repr_png_` returns raw PNG bytes, so `b64decode` raised `binascii.Error` and the renderer fell back to the `[image/png]` placeholder. Now bytes pass through untouched and only str payloads get decoded. Red/green: `test_raw_png_bytes_render_like_pil` confirmed failing first, then fixed. 28/28 pass.
