### PR TITLE
Add job control for PTY shell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 - `image/png` rendering via `kittytgp`
 - matplotlib inline support
 - Includes display objects, streams, and rich results in stored history
+- Job control for shell commands: suspend the running command (Ctrl-Z by
+  default), then `jobs`, `fg`, and `bg` as in bash
 
 ## Install
 

--- a/ipythonng/extension.py
+++ b/ipythonng/extension.py
@@ -99,7 +99,7 @@ def _report_stop(shell, job):
     n = next((k for k,v in jobs.items() if v is job), None) or max(jobs, default=0)+1
     jobs[n] = job
     print(f'\n[{n}]+ Stopped  {job.cmd}')
-    shell.user_ns['_exit_code'] = 148  # 128+SIGTSTP, as bash
+    shell.user_ns['_exit_code'] = 128 + signal.SIGTSTP  # as bash reports it
 
 def _finish_fg(shell, job):
     "Reap `job` and hand its output to history"

--- a/ipythonng/extension.py
+++ b/ipythonng/extension.py
@@ -5,6 +5,9 @@ from typing import Any
 
 from fastcore.basics import patch,patch_to
 from IPython.core.history import HistoryOutput
+from IPython.core.magic import Magics, line_magic, magics_class
+
+from .jobs import spawn_job, copy_job, finish_job
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.core.ultratb import SyntaxTB
 from kittytgp import build_render_bytes
@@ -69,38 +72,75 @@ def _set_pty_size(master_fd):
     except Exception: pass
 
 def _system_pty(self, cmd):
-    "Run `cmd` in a PTY so interactive programs work, capturing output for history."
-    from fastcore.xtras import clean_cli_output
+    "Run `cmd` in a PTY with job control, capturing output for history"
     cmd = self.var_expand(cmd, depth=1)
-    captured = []
-    def _read(fd):
-        data = os.read(fd, 1024)
-        captured.append(data)
-        return data
-    pid, master_fd = pty.fork()
-    if pid == 0: os.execlp(os.environ.get('SHELL', '/bin/sh'), 'sh', '-c', cmd)
-    _set_pty_size(master_fd)
+    _run_fg(self, spawn_job(cmd))
+
+def _run_fg(shell, job):
+    "Attach `job` to the terminal until it exits or is suspended"
+    _set_pty_size(job.master_fd)
     prev_sigwinch = signal.getsignal(signal.SIGWINCH)
-    signal.signal(signal.SIGWINCH, lambda *_: _set_pty_size(master_fd))
+    signal.signal(signal.SIGWINCH, lambda *_: _set_pty_size(job.master_fd))
     try:
         mode = termios.tcgetattr(pty.STDIN_FILENO)
         tty.setraw(pty.STDIN_FILENO)
         restore = True
     except termios.error: restore = False
-    try: pty._copy(master_fd, _read, pty._read)
+    try: reason = copy_job(job)
     finally:
         if restore: termios.tcsetattr(pty.STDIN_FILENO, termios.TCSAFLUSH, mode)
         signal.signal(signal.SIGWINCH, prev_sigwinch)
-    os.close(master_fd)
-    _, status = os.waitpid(pid, 0)
-    exit_code = os.waitstatus_to_exitcode(status)
-    if exit_code > 128: exit_code = -(exit_code - 128)
-    self.user_ns['_exit_code'] = exit_code
-    raw = b''.join(captured).decode('utf-8', errors='replace')
-    clean = clean_cli_output(raw)
+    if reason=='stopped': _report_stop(shell, job)
+    else: _finish_fg(shell, job)
+
+def _report_stop(shell, job):
+    "Add suspended `job` to the jobs table and report it"
+    jobs = shell._ipythonng_jobs
+    n = next((k for k,v in jobs.items() if v is job), None) or max(jobs, default=0)+1
+    jobs[n] = job
+    print(f'\n[{n}]+ Stopped  {job.cmd}')
+    shell.user_ns['_exit_code'] = 148  # 128+SIGTSTP, as bash
+
+def _finish_fg(shell, job):
+    "Reap `job` and hand its output to history"
+    from fastcore.xtras import clean_cli_output
+    shell._ipythonng_jobs = {k:v for k,v in shell._ipythonng_jobs.items() if v is not job}
+    shell.user_ns['_exit_code'] = finish_job(job)
+    clean = clean_cli_output(b''.join(job.captured).decode('utf-8', errors='replace'))
     if clean.strip():
-        ext = getattr(self, '_ipythonng_extension', None)
+        ext = getattr(shell, '_ipythonng_extension', None)
         if ext: ext._pty_output = clean
+
+@magics_class
+class JobMagics(Magics):
+    "Job control magics: `%jobs`, `%fg`, `%bg`"
+    def _pick(self, line):
+        jobs = self.shell._ipythonng_jobs
+        n = int(line) if line.strip() else max(jobs, default=0)
+        if n not in jobs: return print(f'no such job: {line.strip() or "(none)"}', file=sys.stderr)
+        return jobs[n]
+
+    @line_magic
+    def jobs(self, line=''):
+        "List stopped and backgrounded jobs"
+        for n,j in sorted(self.shell._ipythonng_jobs.items()): print(f'[{n}]  {j.state:8} {j.cmd}')
+
+    @line_magic
+    def fg(self, line=''):
+        "Resume job `line` (default: most recent) in the foreground"
+        if (j := self._pick(line)) is None: return
+        try: os.killpg(j.pgid, signal.SIGCONT)
+        except ProcessLookupError: pass
+        j.state = 'running'
+        _run_fg(self.shell, j)
+
+    @line_magic
+    def bg(self, line=''):
+        "Resume job `line` (default: most recent) in the background"
+        if (j := self._pick(line)) is None: return
+        try: os.killpg(j.pgid, signal.SIGCONT)
+        except ProcessLookupError: pass
+        j.state = 'running'
 
 
 class IPythonNGExtension:
@@ -294,6 +334,8 @@ class IPythonNGExtension:
 
 def load_ipython_extension(shell):
     if getattr(shell, "_ipythonng_extension", None) is not None: return
+    shell._ipythonng_jobs = getattr(shell, "_ipythonng_jobs", {})
+    shell.register_magics(JobMagics(shell))
     lts = shell.input_transformer_manager.line_transforms
     if _await_magic not in lts: lts.append(_await_magic)
     extension = IPythonNGExtension(shell)

--- a/ipythonng/jobs.py
+++ b/ipythonng/jobs.py
@@ -1,0 +1,95 @@
+"Job control for PTY commands, via a shepherd process that relays suspend/exit events"
+import os, pty, select
+from fastcore.basics import store_attr
+
+__all__ = ['Job', 'spawn_job', 'copy_job', 'finish_job']
+
+class Job:
+    "A PTY command: `pid` is its shepherd, `pgid` the command's own process group"
+    def __init__(self, cmd, pid, pgid, master_fd, status_r):
+        store_attr()
+        self.captured,self.exit_code,self.state = [],None,'running'
+    def __repr__(self): return f'Job({self.cmd!r}, pgid={self.pgid}, {self.state})'
+
+def _read_line(fd):
+    buf = b''
+    while not buf.endswith(b'\n'):
+        b = os.read(fd, 1)
+        if not b: break
+        buf += b
+    return buf.decode()
+
+def _writen(fd, data):
+    while data: data = data[os.write(fd, data):]
+
+def _shepherd(cmd, sh, status_w):
+    "Run `cmd` in its own pgrp (keeps it suspendable) and relay its events -- runs inside the pty session"
+    cmd_pid = os.fork()
+    if cmd_pid==0:
+        os.setpgid(0, 0)
+        os.execlp(sh, 'sh', '-c', cmd)
+    try: os.setpgid(cmd_pid, cmd_pid)
+    except OSError: pass
+    os.tcsetpgrp(0, cmd_pid)
+    os.write(status_w, f'pgid {cmd_pid}\n'.encode())
+    while True:
+        _, st = os.waitpid(cmd_pid, os.WUNTRACED)
+        if os.WIFSTOPPED(st): os.write(status_w, b'stopped\n')
+        else:
+            ec = os.waitstatus_to_exitcode(st)
+            os.write(status_w, f'exited {ec}\n'.encode())
+            os._exit(ec if ec>=0 else 128-ec)
+
+def spawn_job(cmd, sh=None):
+    "Fork a shepherd on a fresh PTY running `cmd`; returns the parent-side `Job`"
+    sh = sh or os.environ.get('SHELL', '/bin/sh')
+    status_r,status_w = os.pipe()
+    pid,master_fd = pty.fork()
+    if pid==0:
+        os.close(status_r)
+        try: _shepherd(cmd, sh, status_w)
+        finally: os._exit(127)
+    os.close(status_w)
+    pgid = int(_read_line(status_r).split()[1])
+    return Job(cmd, pid, pgid, master_fd, status_r)
+
+def _drain(job, out_fd):
+    "Forward any buffered pty output"
+    while select.select([job.master_fd], [], [], 0)[0]:
+        try: data = os.read(job.master_fd, 1024)
+        except OSError: return
+        if not data: return
+        job.captured.append(data)
+        _writen(out_fd, data)
+
+def copy_job(job, in_fd=pty.STDIN_FILENO, out_fd=pty.STDOUT_FILENO):
+    "Shuttle bytes between `in_fd`/`out_fd` and the job's pty until it exits ('eof') or suspends ('stopped')"
+    fds = [job.master_fd, job.status_r, in_fd]
+    while True:
+        rfds,_,_ = select.select(fds, [], [])
+        if job.master_fd in rfds:
+            try: data = os.read(job.master_fd, 1024)
+            except OSError: data = b''
+            if not data: return 'eof'
+            job.captured.append(data)
+            _writen(out_fd, data)
+        if in_fd in rfds:
+            data = os.read(in_fd, 1024)
+            if data: _writen(job.master_fd, data)
+            else: fds.remove(in_fd)
+        if job.status_r in rfds:
+            msg = _read_line(job.status_r).split()
+            if msg and msg[0]=='stopped':
+                _drain(job, out_fd)
+                job.state = 'stopped'
+                return 'stopped'
+            if msg and msg[0]=='exited': job.exit_code = int(msg[1])
+            fds.remove(job.status_r)
+
+def finish_job(job):
+    "Reap the shepherd, then close the pty; returns the command's exit code (negative = killed by that signal)"
+    _, status = os.waitpid(job.pid, 0)  # reap first: closing the master would SIGHUP the shepherd
+    os.close(job.master_fd)
+    os.close(job.status_r)
+    ec = os.waitstatus_to_exitcode(status)
+    return -(ec-128) if ec>128 else ec

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,91 @@
+import os, signal, time, pytest
+from IPython.terminal.interactiveshell import TerminalInteractiveShell
+from traitlets.config import Config
+
+from ipythonng import load_ipython_extension
+from ipythonng.jobs import spawn_job, copy_job, finish_job
+
+def attach(job):
+    "Run `job` against dummy in/out pipes, returning why it detached"
+    rin,win = os.pipe(); rout,wout = os.pipe()
+    try: return copy_job(job, in_fd=rin, out_fd=wout)
+    finally:
+        for fd in (rin,win,rout,wout): os.close(fd)
+
+def kill(job):
+    try: os.killpg(job.pgid, signal.SIGKILL)
+    except ProcessLookupError: pass
+    return finish_job(job)
+
+def test_signal_suspends():
+    job = spawn_job('sleep 5')
+    os.killpg(job.pgid, signal.SIGTSTP)
+    assert attach(job)=='stopped'
+    kill(job)
+
+def test_ctrl_z_suspends():
+    "the ^Z byte typed at the terminal must suspend the job"
+    job = spawn_job('sleep 5')
+    os.write(job.master_fd, b'\x1a')
+    assert attach(job)=='stopped'
+    kill(job)
+
+def test_suspend_resume_captures_all_output():
+    job = spawn_job('echo before && kill -TSTP 0 && echo after')
+    assert attach(job)=='stopped'
+    assert b'before' in b''.join(job.captured)
+    os.killpg(job.pgid, signal.SIGCONT)
+    assert attach(job)=='eof'
+    assert b'after' in b''.join(job.captured)
+    assert finish_job(job)==0
+
+def test_exit_codes():
+    assert finish_job(spawn_job('exit 7'))==7
+    job = spawn_job('sleep 5')
+    time.sleep(0.2)
+    os.killpg(job.pgid, signal.SIGTERM)
+    assert finish_job(job)==-signal.SIGTERM
+
+def test_stdin_reaches_job():
+    rin,win = os.pipe(); rout,wout = os.pipe()
+    job = spawn_job('read x && echo got:$x')
+    os.write(win, b'hi\n')
+    assert copy_job(job, in_fd=rin, out_fd=wout)=='eof'
+    assert b'got:hi' in b''.join(job.captured)
+    finish_job(job)
+    for fd in (rin,win,rout,wout): os.close(fd)
+
+@pytest.fixture
+def shell(tmp_path):
+    TerminalInteractiveShell.clear_instance()
+    config = Config()
+    config.TerminalInteractiveShell.simple_prompt = True
+    config.HistoryManager.hist_file = str(tmp_path/'history.sqlite')
+    shell = TerminalInteractiveShell.instance(config=config)
+    load_ipython_extension(shell)
+    try: yield shell
+    finally:
+        for j in list(shell._ipythonng_jobs.values()): kill(j)
+        shell.history_manager.writeout_cache()
+        shell.history_manager.end_session()
+        shell._atexit_once = lambda: None
+        TerminalInteractiveShell.clear_instance()
+
+def test_suspended_job_returns_prompt(shell, capsys):
+    shell.run_cell('!kill -TSTP 0', store_history=True)
+    assert 'Stopped' in capsys.readouterr().out
+    shell.run_cell('%jobs', store_history=True)
+    assert 'kill -TSTP 0' in capsys.readouterr().out
+
+def test_fg_resumes(shell):
+    shell.run_cell('!kill -TSTP 0 && echo resumed', store_history=True)
+    shell.run_cell('%fg', store_history=True)
+    assert shell._ipythonng_jobs=={} and shell.user_ns['_exit_code']==0
+    assert 'resumed' in shell.history_manager.output_hist_reprs.get(shell.execution_count-1, '')
+
+def test_bg_runs_without_terminal(shell):
+    shell.run_cell('!kill -TSTP 0 && echo done', store_history=True)
+    shell.run_cell('%bg', store_history=True)
+    time.sleep(0.5)
+    shell.run_cell('%fg', store_history=True)
+    assert shell._ipythonng_jobs=={} and shell.user_ns['_exit_code']==0


### PR DESCRIPTION
## Summary
Adds bash-like job control to `!cmd` invocations:

- **Suspend** the running command with **Ctrl-Z** (SIGTSTP)
- **`%jobs`** — list stopped and backgrounded jobs
- **`%fg`** — resume a job in the foreground
- **`%bg`** — resume a job in the background

## Implementation
- New `ipythonng/jobs.py`: a `Job` class backed by a *shepherd* process that runs the command in its own process group (so it stays suspendable) and relays suspend/exit events over a status pipe.
- `_system_pty` refactored into `_run_fg`/`_finish_fg`/`_report_stop` to handle both normal exit and suspension.
- New `JobMagics` class registers `%jobs`, `%fg`, `%bg` line magics.
- Full test suite in `tests/test_jobs.py` covering signal/keyboard suspend, resume output capture, exit codes, stdin forwarding, and end-to-end shell integration.

## Notes

- A backgrounded job's output parks in the pty buffer (~64K) until `fg`; chatty bg jobs block on write until drained
- v1 gaps: no "stopped jobs" warning on shell exit; `unload` doesn't deregister the magics

## Demos


https://github.com/user-attachments/assets/ef592df9-698f-4c75-a703-68dfbef81a8e

