### PR TITLE
Stop continuation prompt for single-line alias/magic commands

### DIFF
--- a/ipythonng/extension.py
+++ b/ipythonng/extension.py
@@ -7,6 +7,8 @@ from fastcore.basics import patch,patch_to
 from IPython.core.history import HistoryOutput
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.core.ultratb import SyntaxTB
+from IPython.core.prefilter import is_shadowed
+from IPython.terminal.interactiveshell import TerminalInteractiveShell
 from kittytgp import build_render_bytes
 from rich.console import Console
 from rich.markdown import Markdown as RichMarkdown
@@ -23,6 +25,16 @@ def structured_traceback(self:SyntaxTB, etype, evalue, etb, tb_offset=None, cont
 async def run_cell_magic(self:InteractiveShell, magic_name, line, cell):
     result = self._orig_run_cell_magic(magic_name, line, cell)
     return await result if inspect.iscoroutine(result) else result
+
+@patch
+def check_complete(self:TerminalInteractiveShell, code):
+    "Complete when the prefilter will hand a single-line command to a magic or alias, else defer to Python judgment"
+    line = code.strip()
+    if '\n' not in line:
+        word,_,rest = line.partition(' ')
+        if self.automagic and rest[:1] not in ('=',',') and self.find_magic(word) and not is_shadowed(word, self):
+            return 'complete', ''
+    return self._orig_check_complete(code)
 
 def _await_magic(lines):
     if lines and 'get_ipython().run_cell_magic(' in lines[0] and 'await ' not in lines[0]: lines[0] = 'await ' + lines[0]

--- a/tests/test_check_complete.py
+++ b/tests/test_check_complete.py
@@ -1,0 +1,42 @@
+import pytest
+from IPython.terminal.interactiveshell import TerminalInteractiveShell
+from traitlets.config import Config
+
+import ipythonng.extension  # applies the check_complete patch
+
+
+@pytest.fixture
+def shell(tmp_path):
+    TerminalInteractiveShell.clear_instance()
+    config = Config()
+    config.TerminalInteractiveShell.simple_prompt = True
+    config.HistoryManager.hist_file = str(tmp_path / "history.sqlite")
+    sh = TerminalInteractiveShell.instance(config=config)
+    try: yield sh
+    finally:
+        sh.history_manager.end_session()
+        sh._atexit_once = lambda: None
+        TerminalInteractiveShell.clear_instance()
+
+
+def test_alias_command_completes(shell):
+    "A filename the tokenizer chokes on must not trigger the continuation prompt"
+    shell.alias_manager.define_alias('git', 'git')
+    assert shell.check_complete('git diff nbs/01_drafting.ipynb') == ('complete', '')
+
+def test_magic_command_completes(shell):
+    assert shell.check_complete('cd nbs/01_drafting')[0] == 'complete'
+
+def test_assignment_beats_command(shell):
+    "`ls = (1,` is Python assignment: continuation prompt must survive"
+    assert shell.check_complete('ls = (1,')[0] == 'incomplete'
+
+def test_shadowed_name_stays_python(shell):
+    shell.alias_manager.define_alias('git', 'git')
+    shell.user_ns['git'] = 1
+    assert shell.check_complete('git diff nbs/01_drafting.ipynb')[0] == 'incomplete'
+
+def test_python_judgment_unchanged(shell):
+    assert shell.check_complete('def f(x):')[0] == 'incomplete'
+    assert shell.check_complete('x = [1,')[0] == 'incomplete'
+    assert shell.check_complete('ls\nx = (')[0] == 'incomplete'  # multiline: no short-circuit


### PR DESCRIPTION
## Problem

IPython's `check_complete` defers to Python's tokenizer for completeness judgment. For single-line inputs that the prefilter will hand to a magic or alias (e.g. `git diff nbs/01_drafting.ipynb`), the tokenizer chokes on the filename and incorrectly reports the input as **incomplete**, triggering a spurious continuation prompt.

 ## Fix

Patches `TerminalInteractiveShell.check_complete` to short-circuit: when a single-line input will be dispatched to a magic or alias (respecting `automagic` and shadowing rules), return `("complete", "")` immediately instead of consulting the tokenizer.

## Behavior preserved

- Python assignments like `ls = (1,` still trigger continuation (assignment beats command detection)
- Shadowed names (a variable in `user_ns` shadows an alias) defer to Python judgment
- Multi-line input is never short-circuited
- Normal Python incompleteness (`def f(x):`, `x = [1,`) is unchanged