### PR TITLE
Skip MIME renderer install when unsupported

### DIFF
--- a/ipythonng/extension.py
+++ b/ipythonng/extension.py
@@ -198,6 +198,7 @@ class IPythonNGExtension:
         try: from ipykernel.zmqshell import ZMQInteractiveShell
         except Exception: ZMQInteractiveShell = None
         if ZMQInteractiveShell is not None and isinstance(self.shell, ZMQInteractiveShell): return
+        if not hasattr(self.shell, "mime_renderers"): return
         self._add_renderer("text/markdown", self._handle_text_markdown)
         self._add_renderer("image/png", self._handle_image_png)
 


### PR DESCRIPTION
This PR check if the shell has `mime_renderers` before installing them, which was failing in solveit where a simple ipymini shell is used.

Original error: 

```
INFO:     127.0.0.1:64307 - "GET /chat_messages_?dlg_name=dlgs%2Fexplore%2Faai-new-repos%2Fmain HTTP/1.1" 200 OK
[_MiniShellApp] WARNING | Error in loading extension: ipythonng
Check your config files in /Users/keremturgutlu/.ipython/profile_default
Traceback (most recent call last):
  File "/Users/keremturgutlu/aai-ws/.venv/lib/python3.12/site-packages/IPython/core/shellapp.py", line 331, in init_extensions
    self.shell.extension_manager.load_extension(ext)
  File "/Users/keremturgutlu/aai-ws/.venv/lib/python3.12/site-packages/IPython/core/extensions.py", line 62, in load_extension
    return self._load_extension(module_str)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/keremturgutlu/aai-ws/.venv/lib/python3.12/site-packages/IPython/core/extensions.py", line 79, in _load_extension
    if self._call_load_ipython_extension(mod):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/keremturgutlu/aai-ws/.venv/lib/python3.12/site-packages/IPython/core/extensions.py", line 129, in _call_load_ipython_extension
    mod.load_ipython_extension(self.shell)
  File "/Users/keremturgutlu/aai-ws/ipythonng/ipythonng/extension.py", line 355, in load_ipython_extension
    extension.load()
  File "/Users/keremturgutlu/aai-ws/ipythonng/ipythonng/extension.py", line 174, in load
    self._install_renderers()
  File "/Users/keremturgutlu/aai-ws/ipythonng/ipythonng/extension.py", line 201, in _install_renderers
    self._add_renderer("text/markdown", self._handle_text_markdown)
  File "/Users/keremturgutlu/aai-ws/ipythonng/ipythonng/extension.py", line 205, in _add_renderer
    self._rendered_mimes[mime] = self.shell.mime_renderers.get(mime)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
```