### PR TITLE
reset all job-control and standard signal dispositions before exec in _shepherd

### DIFF
--- a/ipythonng/jobs.py
+++ b/ipythonng/jobs.py
@@ -36,7 +36,8 @@ def _shepherd(cmd, sh, status_w):
         os.setpgid(0, 0)
         signal.signal(signal.SIGTTOU, signal.SIG_IGN)
         os.tcsetpgrp(0, os.getpgrp())
-        signal.signal(signal.SIGTTOU, signal.SIG_DFL)  # SIG_IGN would survive the exec
+        # reset childs disposition
+        for s in (signal.SIGINT,signal.SIGQUIT,signal.SIGTSTP,signal.SIGTTIN,signal.SIGTTOU,signal.SIGPIPE): signal.signal(s, signal.SIG_DFL)
         os.execlp(sh, 'sh', '-c', cmd)
     try: os.setpgid(cmd_pid, cmd_pid)
     except OSError: pass


### PR DESCRIPTION
## Summary

The `_shepherd` helper previously only reset `SIGTTOU` to `SIG_DFL` before calling `os.execlp`, leaving other signal dispositions (inherited from the parent / IPython process) untouched.

## Problem

Child processes spawned via `sh -c` could inherit non-default dispositions for signals like `SIGINT`, `SIGQUIT`, `SIGTSTP`, `SIGTTIN`, `SIGTTOU`, and `SIGPIPE`. An ignored or otherwise altered disposition would silently
survive the `exec`, causing unexpected behavior in the child — e.g. `Ctrl-C`/`Ctrl-\\`/`Ctrl-Z` not working, or `SIGPIPE` being ignored.

## Fix

Reset the full set of job-control and standard signals to `SIG_DFL` right before `execlp`, so the child starts with the conventional default dispositions.